### PR TITLE
[#1] support for UNIX socket

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ requires 'Net::Server';
 requires 'Server::Starter' => 0.02;
 test_requires 'LWP::Simple';
 test_requires 'Test::TCP' => 0.06;
+test_requires 'Test::UNIXSock';
 test_requires 'HTTP::Server::Simple::CGI';
 
 auto_include;

--- a/lib/Net/Server/SS/PreFork.pm
+++ b/lib/Net/Server/SS/PreFork.pm
@@ -31,7 +31,7 @@ sub pre_bind {
             }
         } else {
             $sock = Net::Server::Proto::UNIX->new();
-	    $sock->NS_proto('UNIX');
+            $sock->NS_proto('UNIX');
             $sock->NS_port($port);
         }
         $sock->fdopen($ports{$port}, 'r')

--- a/t/03-unix.pl
+++ b/t/03-unix.pl
@@ -1,0 +1,22 @@
+#! /usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib qw(blib/lib lib);
+
+use IO::Socket::UNIX;
+use Server::Starter qw(server_ports);
+
+my $listener = IO::Socket::UNIX->new()
+    or die "failed to create unix socket:$!";
+$listener->fdopen((values %{server_ports()})[0], 'w')
+    or die "failde to bind to listening socket:$!";
+
+while (1) {
+    if (my $conn = $listener->accept) {
+        while ($conn->sysread(my $buf, 7) > 0) {
+	    $conn->syswrite(getppid);
+        }
+    }
+}

--- a/t/03-unix.t
+++ b/t/03-unix.t
@@ -24,6 +24,7 @@ test_unix_sock(
         ) or die "failed to connect to unix socket:$!";
         chomp(my $worker_pid = <$socket>);
         like($worker_pid, qr/^\d+$/, 'send request and get pid');
+        $socket->close;
         kill 'HUP', $server_pid;
         sleep 5;
         $socket = IO::Socket::UNIX->new(
@@ -32,5 +33,6 @@ test_unix_sock(
         chomp(my $new_worker_pid = <$socket>);
         like($new_worker_pid, qr/^\d+$/, 'send request and get pid');
         isnt($worker_pid, $new_worker_pid, 'worker pid changed');
+        $socket->close;
     },
 );

--- a/t/03-unix.t
+++ b/t/03-unix.t
@@ -13,24 +13,28 @@ test_unix_sock(
         my $path = shift;
         start_server(
             path => $path,
-            exec => [ $^X, qw(t/01-httpd.pl) ],
+            exec => [ $^X, qw(t/03-unix.pl) ],
         );
     },
     client => sub {
         my ($path, $server_pid) = @_;
         sleep 1;
-        printf( "path = %s\n" , $path);
-        my $worker_pid;
-        my $new_worker_pid;
+
         my $socket = IO::Socket::UNIX->new(
-          Type => SOCK_STREAM,
           Peer => $path,
-        );
-        chomp( $worker_pid = <$socket>) ;
+        ) or die "failed to connect to unix socket:$!";
+        $socket->syswrite('getppid', 7);
+        $socket->sysread(my $worker_pid, 10);
         like($worker_pid, qr/^\d+$/, 'send request and get pid');
         kill 'HUP', $server_pid;
         sleep 5;
-        chomp( $new_worker_pid = <$socket>);
+
+        $socket = IO::Socket::UNIX->new(
+          Peer => $path,
+        ) or die "failed to connect to unix socket:$!";
+
+        $socket->syswrite('getppid', 7);
+        $socket->sysread(my $new_worker_pid, 10);
         like($new_worker_pid, qr/^\d+$/, 'send request and get pid');
         isnt($worker_pid, $new_worker_pid, 'worker pid changed');
     },

--- a/t/03-unix.t
+++ b/t/03-unix.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use LWP::Simple;
+use Test::UNIXSock;
+use Test::More tests => 3;
+use IO::Socket::UNIX;
+
+use Server::Starter qw(start_server);
+
+test_unix_sock(
+    server => sub {
+        my $path = shift;
+        start_server(
+            path => $path,
+            exec => [ $^X, qw(t/01-httpd.pl) ],
+        );
+    },
+    client => sub {
+        my ($path, $server_pid) = @_;
+        sleep 1;
+        printf( "path = %s\n" , $path);
+        my $worker_pid;
+        my $new_worker_pid;
+        my $socket = IO::Socket::UNIX->new(
+          Type => SOCK_STREAM,
+          Peer => $path,
+        );
+        chomp( $worker_pid = <$socket>) ;
+        like($worker_pid, qr/^\d+$/, 'send request and get pid');
+        kill 'HUP', $server_pid;
+        sleep 5;
+        chomp( $new_worker_pid = <$socket>);
+        like($new_worker_pid, qr/^\d+$/, 'send request and get pid');
+        isnt($worker_pid, $new_worker_pid, 'worker pid changed');
+    },
+);


### PR DESCRIPTION
@kazuho @miyagawa
This is a least modification for UNIX socket.
My psgi work fine by this modification.

But `t/03-unix.t` have same error.

```
Bad arg length for Socket::unpack_sockaddr_in, length is 2, should be 16 at lib/5.16.0/x86_64-linux/Socket.pm line 790, <DATA> line 16.
```

Could you something help?
